### PR TITLE
Add 1.18.1 Support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
 }
 
 group 'br.com.gamemods'
-version '2.0.1-SNAPSHOT'
+version '2.0.2-SNAPSHOT'
 
 sourceSets.main.java.srcDirs = ["src/main/kotlin"]
 sourceSets.test.java.srcDirs = ["src/test/kotlin"]

--- a/src/main/kotlin/br/com/gamemods/regionmanipulator/Chunk.kt
+++ b/src/main/kotlin/br/com/gamemods/regionmanipulator/Chunk.kt
@@ -30,7 +30,7 @@ data class Chunk(var lastModified: Date, var nbtFile: NbtFile) {
      * The `Level` tag, all chunk details like entities, tile entities, chunk sections, etc are stored here.
      */
     val level: NbtCompound
-        get() = compound//.getCompound("Level")
+        get() = Optional.ofNullable(compound.getNullableCompound("Level")).orElse(compound)
 
     /**
      * The X/Z position in the world where this chunk resides.

--- a/src/main/kotlin/br/com/gamemods/regionmanipulator/Chunk.kt
+++ b/src/main/kotlin/br/com/gamemods/regionmanipulator/Chunk.kt
@@ -30,7 +30,7 @@ data class Chunk(var lastModified: Date, var nbtFile: NbtFile) {
      * The `Level` tag, all chunk details like entities, tile entities, chunk sections, etc are stored here.
      */
     val level: NbtCompound
-        get() = compound.getCompound("Level")
+        get() = compound//.getCompound("Level")
 
     /**
      * The X/Z position in the world where this chunk resides.


### PR DESCRIPTION
I'm not familiar with Kotlin, so pardon if this is not a good solution. Feel free to commit to this PR if there is a better solution

In 1.18, Chunks move content out of the "Level" compound into the parent chunk compound. There is a catch, however, that only chunks updated will have this change. I incorporated a fix that both supports this behavior, and previous versions.

I also updated the version to 2.0.2-SNAPSHOT, this was for my own sake. Feel free to change this as well.